### PR TITLE
#48 register beacon regions for monitring

### DIFF
--- a/CoolestProjects/CoolestProjects/AppDelegate.m
+++ b/CoolestProjects/CoolestProjects/AppDelegate.m
@@ -23,10 +23,10 @@
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
     // Override point for customization after application launch.
-    self.beaconNotificationManager = BeaconNotificationsManager.sharedInstance;
-    
     [FIRApp configure];
     [FIRDatabase database].persistenceEnabled = YES;
+
+    self.beaconNotificationManager = BeaconNotificationsManager.sharedInstance;
     
     [self preloadContent];
     

--- a/CoolestProjects/CoolestProjects/CoolestProjects-Bridging-Header.h
+++ b/CoolestProjects/CoolestProjects/CoolestProjects-Bridging-Header.h
@@ -10,3 +10,5 @@
 #import "CPASponsorTier.h"
 #import "CPASponsor.h"
 #import "CPAAbout.h"
+#import "CPARegion.h"
+#import "CPABeacon.h"

--- a/CoolestProjects/Services/CPAFirebaseService.h
+++ b/CoolestProjects/Services/CPAFirebaseService.h
@@ -39,6 +39,7 @@
 /**
  *  Get a list of the tier and sponsors for that tier.
  */
-- (void)getRegionsWithCompletionBlock:(nullable void(^)(NSArray<CPARegion *> * _Nullable regions, NSError * _Nullable error))completionBlock;
+- (void)getRegionsWithCompletionBlock:(nullable void(^)(NSArray<CPARegion *> * _Nullable regions, NSError * _Nullable error))completionBlock
+NS_SWIFT_NAME(getRegions(_:));
 
 @end

--- a/CoolestProjects/Services/Models/CPABeacon.h
+++ b/CoolestProjects/Services/Models/CPABeacon.h
@@ -8,9 +8,9 @@
 
 #import "CPAObject.h"
 
-@protocol CPABeacon <NSObject>
+@protocol CPABeacon;
 
-@end
+NS_ASSUME_NONNULL_BEGIN
 
 @interface CPABeacon : CPAObject
 
@@ -20,3 +20,5 @@
 @property(nonatomic, copy) NSString *uuid;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/CoolestProjects/Services/Models/CPARegion.h
+++ b/CoolestProjects/Services/Models/CPARegion.h
@@ -9,9 +9,13 @@
 #import "CPAObject.h"
 #import "CPABeacon.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface CPARegion : CPAObject
 
-@property (nonatomic, strong) NSArray<CPABeacon> *beacons;
+@property (nonatomic, strong) NSArray<CPABeacon *> <CPABeacon> *beacons;
 @property (nonatomic, copy) NSString *regionId;
 
 @end
+
+NS_ASSUME_NONNULL_END


### PR DESCRIPTION
- fixed crash due to initialisation of beaconNotificationManger prop in the app delegate before firebase setup
- added CPARegion and CPABeacon to the bridging header + some refactoring to allow better Swift interop (nullability and generics)
- renamed `getRegionsWithCompletionBlock` for Swift
- added extensions functions on CPARegion and CPABeacon to convert to CLBeaconRegion
- call getRegions from beaconManager + logic to register new regions and unregister missing regions