### PR TITLE
#58 Check BLE Power On/Off and display alert to the user

### DIFF
--- a/CoolestProjects/CoolestProjects.xcodeproj/project.pbxproj
+++ b/CoolestProjects/CoolestProjects.xcodeproj/project.pbxproj
@@ -66,6 +66,9 @@
 		A97B8C2E1EAD724E00B2A512 /* RegionInteractionsInvalidData.json in Resources */ = {isa = PBXBuildFile; fileRef = A97B8C2D1EAD724E00B2A512 /* RegionInteractionsInvalidData.json */; };
 		A97B8C351EAEB02800B2A512 /* MessagesService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A97B8C341EAEB02800B2A512 /* MessagesService.swift */; };
 		A97B8C371EAEB7EF00B2A512 /* Message.swift in Sources */ = {isa = PBXBuildFile; fileRef = A97B8C361EAEB7EF00B2A512 /* Message.swift */; };
+		A97B8C3D1EC7A18900B2A512 /* CoreBluetooth.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A97B8C3C1EC7A18900B2A512 /* CoreBluetooth.framework */; };
+		A97B8C3F1EC7B80A00B2A512 /* BluetoothAlertManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A97B8C3E1EC7B80A00B2A512 /* BluetoothAlertManager.swift */; };
+		A97B8C411EC7BFF600B2A512 /* Alerts.strings in Resources */ = {isa = PBXBuildFile; fileRef = A97B8C401EC7BFF600B2A512 /* Alerts.strings */; };
 		A98010C81D0522E800AABC90 /* Stages.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A98010C71D0522E800AABC90 /* Stages.xcassets */; };
 		A98010CA1D0524A300AABC90 /* Stages.strings in Resources */ = {isa = PBXBuildFile; fileRef = A98010C91D0524A300AABC90 /* Stages.strings */; };
 		A98010D31D05259F00AABC90 /* StagesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A98010D11D05259F00AABC90 /* StagesViewController.swift */; };
@@ -195,6 +198,9 @@
 		A97B8C341EAEB02800B2A512 /* MessagesService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MessagesService.swift; sourceTree = "<group>"; };
 		A97B8C361EAEB7EF00B2A512 /* Message.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Message.swift; sourceTree = "<group>"; };
 		A97B8C3B1EB29B1600B2A512 /* Coolest Projects.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "Coolest Projects.entitlements"; sourceTree = "<group>"; };
+		A97B8C3C1EC7A18900B2A512 /* CoreBluetooth.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreBluetooth.framework; path = System/Library/Frameworks/CoreBluetooth.framework; sourceTree = SDKROOT; };
+		A97B8C3E1EC7B80A00B2A512 /* BluetoothAlertManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BluetoothAlertManager.swift; sourceTree = "<group>"; };
+		A97B8C401EC7BFF600B2A512 /* Alerts.strings */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; path = Alerts.strings; sourceTree = "<group>"; };
 		A98010C71D0522E800AABC90 /* Stages.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Stages.xcassets; path = images/Stages.xcassets; sourceTree = "<group>"; };
 		A98010C91D0524A300AABC90 /* Stages.strings */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = Stages.strings; path = strings/Stages.strings; sourceTree = "<group>"; };
 		A98010D11D05259F00AABC90 /* StagesViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = StagesViewController.swift; path = Stages/StagesViewController/StagesViewController.swift; sourceTree = "<group>"; };
@@ -250,6 +256,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A97B8C3D1EC7A18900B2A512 /* CoreBluetooth.framework in Frameworks */,
 				3A02C858EBAB3C0EB32DEEC3 /* Pods_CoolestProjects.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -485,6 +492,7 @@
 		A8B1DA2B3A2CA95451BA172C /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				A97B8C3C1EC7A18900B2A512 /* CoreBluetooth.framework */,
 				194788837311B5F45B6240AD /* Pods_CoolestProjects.framework */,
 				1BB508B9D65AD4A13FA74B39 /* Pods_CoolestProjectsTests.framework */,
 			);
@@ -521,6 +529,7 @@
 				440C94751D05A6B200846321 /* Speakers.strings */,
 				E10F18F81D06F8C500AE44AC /* Menu.strings */,
 				E1C604301D0DDD0E00931C38 /* Maps.strings */,
+				A97B8C401EC7BFF600B2A512 /* Alerts.strings */,
 			);
 			name = strings;
 			sourceTree = "<group>";
@@ -541,6 +550,7 @@
 			isa = PBXGroup;
 			children = (
 				A96EA6631EA6C7750021990F /* BeaconNotificationsManager.swift */,
+				A97B8C3E1EC7B80A00B2A512 /* BluetoothAlertManager.swift */,
 			);
 			path = BeaconManager;
 			sourceTree = "<group>";
@@ -906,6 +916,7 @@
 				A91C07A61D0101C5005271FE /* Localizable.strings in Resources */,
 				A93BCD2B1D0DFA8000005DB2 /* Coderdojo2015-107.jpg in Resources */,
 				E1C6042F1D0DDC9D00931C38 /* about.html in Resources */,
+				A97B8C411EC7BFF600B2A512 /* Alerts.strings in Resources */,
 				A93BCD361D0E232400005DB2 /* Projects.storyboard in Resources */,
 				4498BFE11D04BCB80085A15C /* SpeakersViewController.xib in Resources */,
 				A9F8DB4E1D0331C100ECE1F3 /* Home.strings in Resources */,
@@ -1045,6 +1056,7 @@
 				A93BCD3F1D0E24A500005DB2 /* GenericDataSource.swift in Sources */,
 				A93BCD401D0E24A500005DB2 /* NibLoadable.swift in Sources */,
 				A9F8DB631D03623B00ECE1F3 /* SponsorBoxTableViewCell.swift in Sources */,
+				A97B8C3F1EC7B80A00B2A512 /* BluetoothAlertManager.swift in Sources */,
 				E1C604191D0DD7E100931C38 /* ProjectsFilterOptionsViewController.swift in Sources */,
 				E1C6041C1D0DD7E100931C38 /* ProjectsViewController.swift in Sources */,
 				25318B1F1CFD7EBC00691791 /* CPASpeaker.m in Sources */,

--- a/CoolestProjects/CoolestProjects/AppDelegate.m
+++ b/CoolestProjects/CoolestProjects/AppDelegate.m
@@ -51,6 +51,12 @@
 
 - (void)applicationDidBecomeActive:(UIApplication *)application {
     // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
+    BOOL isAuthorizedForMonitoring = self.beaconNotificationManager.isAuthorizedForMonitoring;
+    BOOL deviceSupportsBLE = self.beaconNotificationManager.deviceSupportsBLE;
+    BOOL isBLEPoweredOff = self.beaconNotificationManager.isBLEPoweredOff;
+    if (deviceSupportsBLE && isAuthorizedForMonitoring && isBLEPoweredOff) {
+        [BluetoothAlertManager.sharedInstance showBluetoothPowerOffAlert];
+    }
 }
 
 - (void)applicationWillTerminate:(UIApplication *)application {

--- a/CoolestProjects/CoolestProjects/BeaconManager/BluetoothAlertManager.swift
+++ b/CoolestProjects/CoolestProjects/BeaconManager/BluetoothAlertManager.swift
@@ -1,0 +1,79 @@
+//
+//  BluetoothAlertManager.swift
+//  CoolestProjects
+//
+//  Created by Valentino Gattuso on 13/05/2017.
+//  Copyright © 2017 coderdojo. All rights reserved.
+//
+
+import Foundation
+import UIKit
+
+class BluetoothAlertManager: NSObject {
+
+    static let sharedInstance = BluetoothAlertManager()
+
+    /// Min time interval between two Bluetooth power off alerts
+    fileprivate let alertTimeInterval: TimeInterval = 1800
+
+    private override init() {
+        super.init()
+        lastAlertDate = UserDefaults.standard.value(forKey: "BluetoothPowerOffAlertDate") as? Date
+    }
+
+    func showBluetoothPowerOffAlert() {
+        guard shouldShowBluetoothPowerOffAlert() else {
+            return
+        }
+
+        let topWindow = UIWindow(frame: UIScreen.main.bounds)
+        topWindow.rootViewController = UIViewController()
+        topWindow.windowLevel = UIWindowLevelAlert + 1
+
+        let alert = UIAlertController(
+            title: NSLocalizedString("bluetoothPowerOff.title", tableName: "Alerts", comment: ""),
+            message: NSLocalizedString("bluetoothPowerOff.message", tableName: "Alerts", comment: ""),
+            preferredStyle: .alert)
+
+        let settingsAction = UIAlertAction(
+            title: NSLocalizedString("settings", tableName: "Alerts", comment: ""),
+            style: .default) { (_) in
+
+                if #available(iOS 10.0, *) {
+                    UIApplication.shared.open(URL(string: "App-Prefs:root=Bluetooth")!)
+                } else {
+                    UIApplication.shared.open(URL(string: "prefs:root=General&path=Bluetooth")!)
+                }
+
+                topWindow.isHidden = true
+        }
+
+        let ignoreAction = UIAlertAction(
+            title: NSLocalizedString("ignore", tableName: "Alerts", comment: ""),
+            style: .cancel) { (_) in
+                topWindow.isHidden = true
+        }
+
+        alert.addAction(settingsAction)
+        alert.addAction(ignoreAction)
+
+        topWindow.makeKeyAndVisible()
+        topWindow.rootViewController?.present(alert, animated: true, completion: { _ in })
+
+        lastAlertDate = Date()
+    }
+
+    fileprivate func shouldShowBluetoothPowerOffAlert() -> Bool {
+        if let lastAlertDate = lastAlertDate {
+            return Date().timeIntervalSince(lastAlertDate) > alertTimeInterval
+        } else {
+            return true
+        }
+    }
+
+    fileprivate var lastAlertDate: Date? {
+        didSet {
+            UserDefaults.standard.set(lastAlertDate, forKey: "BluetoothPowerOffAlertDate")
+        }
+    }
+}

--- a/CoolestProjects/CoolestProjects/Maps/MapsViewController/MapsViewController.swift
+++ b/CoolestProjects/CoolestProjects/Maps/MapsViewController/MapsViewController.swift
@@ -23,7 +23,7 @@ class MapsViewController: BaseViewController {
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        BeaconNotificationsManager.sharedInstance.requestAuthorization()
+        BeaconNotificationsManager.sharedInstance.setupBeaconsIfNeeded()
     }
 }
 

--- a/CoolestProjects/CoolestProjects/Resources/Alerts.strings
+++ b/CoolestProjects/CoolestProjects/Resources/Alerts.strings
@@ -1,0 +1,12 @@
+/* 
+  Alerts.strings
+  CoolestProjects
+
+  Created by Valentino Gattuso on 13/05/2017.
+  Copyright © 2017 coderdojo. All rights reserved.
+*/
+
+"bluetoothPowerOff.title" = "Turn On Bluetooth";
+"bluetoothPowerOff.message" = "We use low-energy Bluetooth and iBeacon devices installed at the RDS Arena to find you inside the hall, and provide relevant information.";
+"settings" = "Settings";
+"ignore" = "Ignore";


### PR DESCRIPTION
- added code to check if the device support BLE. if unsupported, skip location manager auth request
- added check on didBecomeActive to display an alert if device supports BLE, location auth is authorized always and BLE is power off
- added localisable strings file
- renamed main method of BeaconNotificationManager
- added BluetoothAlertManager responsible of building the alert and check if 30 min have passed before presenting the alert
- the alert links to the Bluetooth section in the Settings app